### PR TITLE
Podspec resource bundle copy + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+
+# CocoaPods
+Pods

--- a/MTDirectionsKit.podspec
+++ b/MTDirectionsKit.podspec
@@ -44,5 +44,6 @@ Pod::Spec.new do |s|
 
   s.libraries   = 'xml2', 'c++', 'icucore', 'z'
   s.requires_arc = true
+  s.resource_bundle = { 'MTDirectionsKit' => 'Resources/MTDirectionsKit.bundle' }
 
 end


### PR DESCRIPTION
We found while using the podspec was missing the resource bundles so that was added.  A gitignore was also added so it doesn't but with files like .ds_store etc
